### PR TITLE
FileSystemAccessRule: No longer tries to write back owner from the ACL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - FileSystemDsc
-  - Fixed FileSystemAccessRule error [(#3)](https://github.com/dsccommunity/FileSystemDsc/issues/3)
+  - Fixed FileSystemAccessRule error ([issue #3](https://github.com/dsccommunity/FileSystemDsc/issues/3)).
 
 ## [1.1.0] - 2020-03-09
 
@@ -16,4 +16,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - FileSystemDsc
   - Added resource FileSystemAccessRule
-  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - FileSystemDsc
-  - Fixed FileSystemAccessRule error ([issue #3](https://github.com/dsccommunity/FileSystemDsc/issues/3)).
+  - Fixed an issue where the owner of ACL was written back resulting in an
+    error "The security identifier is not allowed to be the owner of this
+    object" ([issue #3](https://github.com/dsccommunity/FileSystemDsc/issues/3)).
 
 ## [1.1.0] - 2020-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- FileSystemDsc
+  - Fixed FileSystemAccessRule error [(#3)](https://github.com/dsccommunity/FileSystemDsc/issues/3)
+
 ## [1.1.0] - 2020-03-09
 
 ### Added
 
 - FileSystemDsc
   - Added resource FileSystemAccessRule
+  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- FileSystemDsc
+- FileSystemAccessRule
   - Fixed an issue where the owner of ACL was written back resulting in an
     error "The security identifier is not allowed to be the owner of this
     object" ([issue #3](https://github.com/dsccommunity/FileSystemDsc/issues/3)).

--- a/source/DSCResources/DSC_FileSystemAccessRule/DSC_FileSystemAccessRule.psm1
+++ b/source/DSCResources/DSC_FileSystemAccessRule/DSC_FileSystemAccessRule.psm1
@@ -136,7 +136,7 @@ function Get-TargetResource
             $script:localizedData.PathExist -f $Identity
         )
 
-        $acl = Get-Acl -Path $Path
+        $acl = Get-ACLAccess -Path $Path
         $accessRules = $acl.Access
 
         <#
@@ -261,7 +261,7 @@ function Set-TargetResource
         New-ObjectNotFoundException -Message $errorMessage
     }
 
-    $acl = Get-Acl -Path $Path
+    $acl = Get-ACLAccess -Path $Path
 
     if ($Ensure -eq 'Present')
     {
@@ -581,4 +581,8 @@ function Test-TargetResource
     }
 
     return $result
+}
+ Function Get-ACLAccess($Path)
+{
+    return (Get-Item -Path $Path).GetAccessControl('Access')
 }

--- a/source/DSCResources/DSC_FileSystemAccessRule/DSC_FileSystemAccessRule.psm1
+++ b/source/DSCResources/DSC_FileSystemAccessRule/DSC_FileSystemAccessRule.psm1
@@ -13,9 +13,6 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
     .PARAMETER Identity
         The identity to set permissions for.
-
-    .NOTES
-        This function uses Get-Acl that was first introduced in Windows Powershell 5.1.
 #>
 function Get-TargetResource
 {
@@ -199,7 +196,7 @@ function Get-TargetResource
         Not used in Set-TargetResource.
 
     .NOTES
-        This function uses Get-Acl and Set-Acl that was first introduced in
+        This function uses Set-Acl that was first introduced in
         Windows Powershell 5.1.
 #>
 function Set-TargetResource
@@ -582,7 +579,34 @@ function Test-TargetResource
 
     return $result
 }
- Function Get-ACLAccess($Path)
+
+<#
+    .SYNOPSIS
+        This function is wrapper for getting the DACL for the specified path.
+
+    .PARAMETER Path
+        The path to the item that should have permissions set.
+
+    .NOTES
+        "Well the limited features of Get-ACL means that you always read the full
+        security descriptor including the owner whether you intended to or not.
+        That means that when you come to write to the object based on a modified
+        version of what you read, you are attempting to write back to the owner
+        attribute.
+
+        The GetAccessControl('Access') method reads only the DACL so when you
+        write it back you are not trying to write something you did not intend to."
+        https://www.mickputley.net/2015/11/set-acl-security-identifier-is-not.html
+        https://github.com/dsccommunity/FileSystemDsc/issues/3
+#>
+function Get-ACLAccess
 {
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Path
+    )
     return (Get-Item -Path $Path).GetAccessControl('Access')
 }

--- a/tests/Unit/DSC_FileSystemAccessRule.Tests.ps1
+++ b/tests/Unit/DSC_FileSystemAccessRule.Tests.ps1
@@ -55,7 +55,7 @@ try
                     Context 'When the node does not belong to a cluster' {
                         BeforeAll {
                             Mock -CommandName Write-Warning
-                            Mock -CommandName Get-Acl
+                            Mock -CommandName Get-ACLAccess
 
                             Mock -CommandName Test-Path -MockWith {
                                 return $false
@@ -67,7 +67,7 @@ try
                         It 'Should not throw and output the correct warning message' {
                             { $script:result = Get-TargetResource @mockGetTargetResourceParameters } | Should -Not -Throw
 
-                            Assert-MockCalled -CommandName Get-Acl -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ACLAccess -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It
 
                             Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
@@ -93,7 +93,7 @@ try
                     Context 'When no cluster disk partition is found that uses the path' {
                         BeforeAll {
                             Mock -CommandName Write-Warning
-                            Mock -CommandName Get-Acl
+                            Mock -CommandName Get-ACLAccess
                             Mock -CommandName Get-CimAssociatedInstance
                             Mock -CommandName Test-Path -MockWith {
                                 return $false
@@ -121,7 +121,7 @@ try
                         It 'Should not throw and output the correct warning message' {
                             { $script:result = Get-TargetResource @mockGetTargetResourceParameters } | Should -Not -Throw
 
-                            Assert-MockCalled -CommandName Get-Acl -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ACLAccess -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It
 
                             Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
@@ -158,7 +158,7 @@ try
                 Context 'When the current node is not a possible cluster resource owner' {
                     BeforeAll {
                         Mock -CommandName Write-Warning
-                        Mock -CommandName Get-Acl
+                        Mock -CommandName Get-ACLAccess
                         Mock -CommandName Test-Path -MockWith {
                             return $false
                         }
@@ -208,7 +208,7 @@ try
                     It 'Should not throw and output the correct warning message' {
                         { $script:result = Get-TargetResource @mockGetTargetResourceParameters } | Should -Not -Throw
 
-                        Assert-MockCalled -CommandName Get-Acl -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-ACLAccess -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It
 
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
@@ -250,7 +250,7 @@ try
                 Context 'When the configuration is present' {
                     Context 'When the path exists' {
                         BeforeAll {
-                            Mock -CommandName Get-Acl -MockWith {
+                            Mock -CommandName Get-ACLAccess -MockWith {
                                 return New-Object -TypeName PSObject |
                                     Add-Member -MemberType 'NoteProperty' -Name 'Access' -Value @(
                                         New-Object -TypeName PSObject |
@@ -269,7 +269,7 @@ try
                         It 'Should get the access rules without throwing' {
                             { $script:result = Get-TargetResource @mockGetTargetResourceParameters } | Should -Not -Throw
 
-                            Assert-MockCalled -CommandName Get-Acl -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-ACLAccess -Exactly -Times 1 -Scope It
                         }
 
                         It 'Should return the state as present' {
@@ -292,7 +292,7 @@ try
                     Context 'When path is not found on the node, but the path is found in a cluster disk partition and the current node is a possible cluster resource owner' {
                         BeforeAll {
                             Mock -CommandName Write-Warning
-                            Mock -CommandName Get-Acl
+                            Mock -CommandName Get-ACLAccess
                             Mock -CommandName Test-Path -MockWith {
                                 return $false
                             }
@@ -347,7 +347,7 @@ try
                         It 'Should not throw and should not output a warning message' {
                             { $script:result = Get-TargetResource @mockGetTargetResourceParameters } | Should -Not -Throw
 
-                            Assert-MockCalled -CommandName Get-Acl -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ACLAccess -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Test-Path -Times 1 -Exactly -Scope It
 
                             Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
@@ -659,7 +659,7 @@ try
                                     } -PassThru -Force
                 }
 
-                Mock -CommandName Get-Acl -MockWith $mockGetAcl
+                Mock -CommandName Get-ACLAccess -MockWith $mockGetAcl
                 Mock -CommandName Set-Acl
             }
 
@@ -710,7 +710,7 @@ try
                         It 'Should call the correct methods and mocks to remove the permissions' {
                             { Set-TargetResource @mockSetTargetResourceParameters } | Should -Not -Throw
 
-                            Assert-MockCalled -CommandName Get-Acl -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-ACLAccess -Exactly -Times 1 -Scope It
 
                             $script:SetAccessRuleMethodCallCount | Should -Be 0
                             $script:PurgeAccessRulesMethodCallCount | Should -Be 0
@@ -731,7 +731,7 @@ try
                             It 'Should call the correct methods and mocks to remove the permissions' {
                                 { Set-TargetResource @mockSetTargetResourceParameters } | Should -Not -Throw
 
-                                Assert-MockCalled -CommandName Get-Acl -Exactly -Times 1 -Scope It
+                                Assert-MockCalled -CommandName Get-ACLAccess -Exactly -Times 1 -Scope It
 
                                 $script:SetAccessRuleMethodCallCount | Should -Be 0
                                 $script:PurgeAccessRulesMethodCallCount | Should -Be 1
@@ -750,7 +750,7 @@ try
                             It 'Should call the correct methods and mocks to remove the permissions' {
                                 { Set-TargetResource @mockSetTargetResourceParameters } | Should -Not -Throw
 
-                                Assert-MockCalled -CommandName Get-Acl -Exactly -Times 1 -Scope It
+                                Assert-MockCalled -CommandName Get-ACLAccess -Exactly -Times 1 -Scope It
 
                                 $script:SetAccessRuleMethodCallCount | Should -Be 0
                                 $script:PurgeAccessRulesMethodCallCount | Should -Be 1
@@ -771,7 +771,7 @@ try
                     It 'Should call the correct methods and mocks to set the permissions' {
                         { Set-TargetResource @mockSetTargetResourceParameters } | Should -Not -Throw
 
-                        Assert-MockCalled -CommandName Get-Acl -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ACLAccess -Exactly -Times 1 -Scope It
 
                         $script:SetAccessRuleMethodCallCount | Should -Be 1
                         $script:PurgeAccessRulesMethodCallCount | Should -Be 0
@@ -797,6 +797,29 @@ try
                         { Set-TargetResource @mockSetTargetResourceParameters } | Should -Throw $mockErrorMessage
                     }
                 }
+            }
+        }
+
+        Describe 'DSC_FileSystemAccessRule\Get-ACLAccess' -Tag 'Helper' {
+            BeforeAll {
+                Mock -CommandName Get-Item -MockWith {
+                    return New-Object -TypeName PSObject |
+                        Add-Member -MemberType 'ScriptMethod' -Name 'GetAccessControl' -Value {
+                            return New-Object -TypeName PSObject |
+                                Add-Member -MemberType 'NoteProperty' -Name 'Access' -Value @(
+                                    New-Object -TypeName PSObject |
+                                        Add-Member -MemberType 'NoteProperty' -Name 'IdentityReference' -Value $mockIdentity -PassThru |
+                                            Add-Member -MemberType 'NoteProperty' -Name 'FileSystemRights' -Value $mockFileSystemRights -PassThru -Force
+                                ) -PassThru -Force
+                        } -PassThru -Force
+                }
+            }
+
+            It 'Should return the correct access control list (ACL)' {
+                $result = Get-ACLAccess -Path 'AnyPath'
+
+                $result.Access[0].IdentityReference | Should -Be $mockIdentity
+                $result.Access[0].FileSystemRights | Should -Be $mockFileSystemRights
             }
         }
     }

--- a/tests/Unit/DSC_FileSystemAccessRule.Tests.ps1
+++ b/tests/Unit/DSC_FileSystemAccessRule.Tests.ps1
@@ -806,6 +806,8 @@ try
                     return New-Object -TypeName PSObject |
                         Add-Member -MemberType 'ScriptMethod' -Name 'GetAccessControl' -Value {
                             return New-Object -TypeName PSObject |
+                                # Regression test for issue #3
+                                Add-Member -MemberType 'NoteProperty' -Name 'Owner' -Value $null -PassThru |
                                 Add-Member -MemberType 'NoteProperty' -Name 'Access' -Value @(
                                     New-Object -TypeName PSObject |
                                         Add-Member -MemberType 'NoteProperty' -Name 'IdentityReference' -Value $mockIdentity -PassThru |
@@ -820,6 +822,9 @@ try
 
                 $result.Access[0].IdentityReference | Should -Be $mockIdentity
                 $result.Access[0].FileSystemRights | Should -Be $mockFileSystemRights
+
+                # Regression test for issue #3
+                $result.Owner | Should -BeNullOrEmpty
             }
         }
     }


### PR DESCRIPTION
My attempt to fix #3 . 

Added code from https://github.com/dsccommunity/xSystemSecurity/pull/14/files.

Did _not_ update the corresponding `Get-Acl` references in the Notes sections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/filesystemdsc/4)
<!-- Reviewable:end -->
