### PR TITLE
FileSystemDsc: Update pipeline and GitHub files

### DIFF
--- a/.github/ISSUE_TEMPLATE/General.md
+++ b/.github/ISSUE_TEMPLATE/General.md
@@ -1,0 +1,7 @@
+---
+name: General question or documentation update
+about: If you have a general question or documentation update suggestion around the resource module.
+---
+<!--
+    Your feedback and support is greatly appreciated, thanks for contributing!
+-->

--- a/.github/ISSUE_TEMPLATE/Problem_with_resource.md
+++ b/.github/ISSUE_TEMPLATE/Problem_with_resource.md
@@ -1,0 +1,62 @@
+---
+name: Problem with a resource
+about: If you have a problem, bug, or enhancement with a resource in this resource module.
+---
+<!--
+    Your feedback and support is greatly appreciated, thanks for contributing!
+
+    ISSUE TITLE:
+    Please prefix the issue title with the resource name, e.g.
+    'ResourceName: Short description of my issue'
+
+    ISSUE DESCRIPTION (this template):
+    Please provide information regarding your issue under each header below.
+    Write N/A under any headers that do not apply to your issue, or if the
+    information is not available.
+
+    NOTE! Sensitive information should be obfuscated.
+
+    PLEASE KEEP THE HEADERS.
+
+    You may remove this comment block, and the other comment blocks,
+    but please keep the headers.
+-->
+#### Details of the scenario you tried and the problem that is occurring
+<!--
+    If you are having an issue with the old xActiveDirectory, please verify
+    your scenario with the latest resources in the new ActiveDirectoryDsc
+    module.
+-->
+
+#### Verbose logs showing the problem
+
+#### Suggested solution to the issue
+
+#### The DSC configuration that is used to reproduce the issue (as detailed as possible)
+```powershell
+# insert configuration here
+```
+
+#### The operating system the target node is running
+<!--
+    Please provide as much as possible about the target node, for example
+    edition, version, build and language.
+    On OS with WMF 5.1 the following command can help get this information.
+
+    Get-ComputerInfo -Property @(
+        'OsName',
+        'OsOperatingSystemSKU',
+        'OSArchitecture',
+        'WindowsVersion',
+        'WindowsBuildLabEx',
+        'OsLanguage',
+        'OsMuiLanguages')
+-->
+
+#### Version and build of PowerShell the target node is running
+<!--
+    To help with this information, please run this command:
+    $PSVersionTable
+-->
+
+#### Version of the DSC module that was used

--- a/.github/ISSUE_TEMPLATE/Resource_proposal.md
+++ b/.github/ISSUE_TEMPLATE/Resource_proposal.md
@@ -1,0 +1,21 @@
+---
+name: New resource proposal
+about: If you have a new resource proposal that you think should be added to this resource module.
+---
+<!--
+    Thank you for contributing and making this resource module better!
+
+    ISSUE TITLE:
+    Please prefix the issue title with a proposed resource name,
+    e.g. 'NewResourceName: New resource proposal'
+
+    ISSUE DESCRIPTION (this template):
+    Please propose the new resource under each header below.
+
+    PLEASE KEEP THE HEADERS, but you may remove this comment block.
+-->
+### Description
+
+### Proposed properties
+
+### Special considerations or limitations

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+<!--
+    Thanks for submitting a Pull Request (PR) to this project.
+    Your contribution to this project is greatly appreciated!
+
+    Please prefix the PR title with the resource name,
+    e.g. 'ResourceName: My short description'.
+    If this is a breaking change, then also prefix the PR title
+    with 'BREAKING CHANGE:',
+    e.g. 'BREAKING CHANGE: ResourceName: My short description'.
+
+    You may remove this comment block, and the other comment blocks, but please
+    keep the headers and the task list.
+-->
+#### Pull Request (PR) description
+<!--
+    Replace this comment block with a description of your PR.
+    Also, make sure you have updated the CHANGELOG.md, see the
+    task list below. An entry in the CHANGELOG.md is mandatory
+    for all PRs.
+-->
+
+#### This Pull Request (PR) fixes the following issues
+<!--
+    If this PR does not fix an open issue, replace this comment block with None.
+    If this PR resolves one or more open issues, replace this comment block with
+    a list of the issues using a GitHub closing keyword, e.g.:
+
+- Fixes #123
+- Fixes #124
+-->
+
+#### Task list
+<!--
+    To aid community reviewers in reviewing and merging your PR, please take
+    the time to run through the below checklist and make sure your PR has
+    everything updated as required.
+
+    Change to [x] for each task in the task list that applies to your PR.
+    For those task that don't apply to you PR, leave those as is.
+-->
+- [ ] Added an entry to the change log under the Unreleased section of the
+      file CHANGELOG.md. Entry should say what was changed and how that
+      affects users (if applicable), and reference the issue being resolved
+      (if applicable).
+- [ ] Resource documentation added/updated in README.md.
+- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
+      and comment-based help.
+- [ ] Comment-based help added/updated.
+- [ ] Localization strings added/updated in all localization files as appropriate.
+- [ ] Examples appropriately added/updated.
+- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
+- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
+- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- FileSystemDsc
+  - Added issue and pull request templates to help contributors.
+
 ### Changed
 
 - FileSystemDsc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- FileSystemDsc
+  - Only run CI pipeline on branch `master` when there are changes to files
+    inside the `source` folder.
+  - The regular expression for `minor-version-bump-message` in the file
+    `GitVersion.yml` was changed to only raise minor version when the
+    commit message contain the word `add`, `adds`, `minor`, `feature`,
+    or `features`.
+
 ## [1.1.1] - 2020-04-19
 
 ### Fixed

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 mode: ContinuousDelivery
 next-version: 1.0.0
 major-version-bump-message: '\s?(breaking|major|breaking\schange)'
-minor-version-bump-message: '\s?(add|feature|minor)'
+minor-version-bump-message: '(adds?|features?|minor)\b'
 patch-version-bump-message: '\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
 assembly-informational-format: '{NuGetVersionV2}+Sha.{Sha}.Date.{CommitDate}'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,8 @@ trigger:
     include:
     - master
   paths:
-    exclude:
-    - CHANGELOG.md
+    include:
+    - source/**/*
   tags:
     include:
     - "v*"


### PR DESCRIPTION
- FileSystemDsc
  - Only run CI pipeline on branch `master` when there are changes to files
    inside the `source` folder.
  - The regular expression for `minor-version-bump-message` in the file
    `GitVersion.yml` was changed to only raise minor version when the
    commit message contain the word `add`, `adds`, `minor`, `feature`,
    or `features`.
  - Added issue and pull request templates to help contributors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/filesystemdsc/5)
<!-- Reviewable:end -->
